### PR TITLE
Releasing as v1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,5 +16,5 @@
   ],
   "license": "MIT",
   "name": "bsp-feature-detect",
-  "version": "0.0.2"
+  "version": "1.0.0"
 }


### PR DESCRIPTION
I'd like to release this plugin as v1.0.0 so that we can start using the full semver ranges in our package managers.